### PR TITLE
Allow setting memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Include with default parameters:
 Set max, min and permgen memory sizes:
 
     class { 'jira':
-      initial_memory => '512m',
+      minimum_memory => '512m',
       maximum_memory => '512m',
       permgen_size   => '2048m',
     }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Set max, min and permgen memory sizes:
       permgen_size   => '2048m',
     }
 
+Set JVM options for jira:
+
+    class { 'jira':
+      jvm_options => '-Djava.net.preferIPv4Stack=true',
+    }
+
 ## License
 
 See [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ Installs a basic JIRA standalone installation in `/opt` and starts it.
 ## Example usage
 
 Include with default parameters:
-```
-include jira
-```
+
+    include jira
+
+Set max, min and permgen memory sizes:
+
+    class { 'jira':
+      initial_memory => '512m',
+      maximum_memory => '512m',
+      permgen_size   => '2048m',
+    }
 
 ## License
 

--- a/files/setenv.sh
+++ b/files/setenv.sh
@@ -1,0 +1,99 @@
+#
+#  Occasionally Atlassian Support may recommend that you set some specific JVM arguments.  You can use this variable below to do that.
+#
+JVM_SUPPORT_RECOMMENDED_ARGS=""
+#
+# The following are the required arguments for JIRA.
+#
+JVM_REQUIRED_ARGS="-Djava.awt.headless=true $JVM_OPTS -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -
+Dmail.mime.decodeparameters=true"
+
+# Uncomment this setting if you want to import data without notifications
+#
+#DISABLE_NOTIFICATIONS=" -Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true"
+
+
+#-----------------------------------------------------------------------------------
+#
+# In general don't make changes below here
+#
+#-----------------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------------
+# This allows us to actually debug GC related issues by correlating timestamps
+# with other parts of the application logs.
+#-----------------------------------------------------------------------------------
+JVM_EXTRA_ARGS="-XX:+PrintGCDateStamps"
+PRGDIR=`dirname "$0"`
+cat "${PRGDIR}"/jirabanner.txt
+
+JIRA_HOME_MINUSD=""
+if [ "$JIRA_HOME" != "" ]; then
+    echo $JIRA_HOME | grep -q " "
+    if [ $? -eq 0 ]; then
+            echo ""
+            echo "--------------------------------------------------------------------------------------------------------------------"
+                echo "   WARNING : You cannot have a JIRA_HOME environment variable set with spaces in it.  This variable is being ignored"
+            echo "--------------------------------------------------------------------------------------------------------------------"
+    else
+                JIRA_HOME_MINUSD=-Djira.home=$JIRA_HOME
+    fi
+fi
+
+JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMEND
+ED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
+
+# Perm Gen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is not valid on IBM JDKs
+if [ -f "${PRGDIR}/permgen.sh" ]; then
+    echo "Detecting JVM PermGen support..."
+    . "${PRGDIR}/permgen.sh"
+    if [ $JAVA_PERMGEN_SUPPORTED = "true" ]; then
+        echo "PermGen switch is supported. Setting to ${JIRA_MAX_PERM_SIZE}"
+        JAVA_OPTS="-XX:MaxPermSize=${JIRA_MAX_PERM_SIZE} ${JAVA_OPTS}"
+    else
+        echo "PermGen switch is NOT supported and will NOT be set automatically."
+    fi
+fi
+
+export JAVA_OPTS
+
+echo ""
+echo "If you encounter issues starting or stopping JIRA, please see the Troubleshooting guide at http://confluence.atlassian.com/display/JIRA/Ins
+tallation+Troubleshooting+Guide"
+echo ""
+if [ "$JIRA_HOME_MINUSD" != "" ]; then
+    echo "Using JIRA_HOME:       $JIRA_HOME"
+fi
+
+# set the location of the pid file
+if [ -z "$CATALINA_PID" ] ; then
+    if [ -n "$CATALINA_BASE" ] ; then
+        CATALINA_PID="$CATALINA_BASE"/work/catalina.pid
+    elif [ -n "$CATALINA_HOME" ] ; then
+        CATALINA_PID="$CATALINA_HOME"/work/catalina.pid
+    fi
+fi
+export CATALINA_PID
+
+if [ -z "$CATALINA_BASE" ]; then
+  if [ -z "$CATALINA_HOME" ]; then
+    LOGBASE=$PRGDIR
+    LOGTAIL=..
+  else
+    LOGBASE=$CATALINA_HOME
+    LOGTAIL=.
+  fi
+else
+  LOGBASE=$CATALINA_BASE
+  LOGTAIL=.
+fi
+
+PUSHED_DIR=`pwd`
+cd $LOGBASE
+cd $LOGTAIL
+LOGBASEABS=`pwd`
+cd $PUSHED_DIR
+
+echo ""
+echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
+

--- a/files/setenv.sh
+++ b/files/setenv.sh
@@ -5,8 +5,7 @@ JVM_SUPPORT_RECOMMENDED_ARGS=""
 #
 # The following are the required arguments for JIRA.
 #
-JVM_REQUIRED_ARGS="-Djava.awt.headless=true $JVM_OPTS -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -
-Dmail.mime.decodeparameters=true"
+JVM_REQUIRED_ARGS="-Djava.awt.headless=true $JVM_OPTS -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true"
 
 # Uncomment this setting if you want to import data without notifications
 #
@@ -40,8 +39,7 @@ if [ "$JIRA_HOME" != "" ]; then
     fi
 fi
 
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMEND
-ED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
+JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
 
 # Perm Gen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is not valid on IBM JDKs
 if [ -f "${PRGDIR}/permgen.sh" ]; then
@@ -58,8 +56,7 @@ fi
 export JAVA_OPTS
 
 echo ""
-echo "If you encounter issues starting or stopping JIRA, please see the Troubleshooting guide at http://confluence.atlassian.com/display/JIRA/Ins
-tallation+Troubleshooting+Guide"
+echo "If you encounter issues starting or stopping JIRA, please see the Troubleshooting guide at http://confluence.atlassian.com/display/JIRA/Installation+Troubleshooting+Guide"
 echo ""
 if [ "$JIRA_HOME_MINUSD" != "" ]; then
     echo "Using JIRA_HOME:       $JIRA_HOME"
@@ -96,4 +93,3 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
-

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,8 @@
 class jira::config {
   include jira::params
 
-  $jira_home = $jira::params::home
+  $jira_home    = $jira::params::home
+  $jira_version = $jira::params::version
 
   user { 'jira':
     ensure => present,
@@ -17,4 +18,14 @@ class jira::config {
     owner   => 'jira',
     require => User['jira'],
   }
+
+  file { 'setenv.sh':
+    ensure => present,
+    path   => "/opt/atlassian-jira-${jira_version}-standalone/bin/setenv.sh",
+    mode   => '0755',
+    owner  => root,
+    group  => root,
+    source => 'puppet:///modules/jira/setenv.sh',
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 #   Explanation of what this parameter affects and what it defaults to.
 #
 class jira (
+  $initial_memory = $jira::params::initial_memory,
+  $maximum_memory = $jira::params::maximum_memory,
+  $permgen_size   = $jira::params::permgen_size
 ) inherits jira::params {
 
   # validate parameters here

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 #   Explanation of what this parameter affects and what it defaults to.
 #
 class jira (
-  $initial_memory = $jira::params::initial_memory,
+  $minimum_memory = $jira::params::minimum_memory,
   $maximum_memory = $jira::params::maximum_memory,
   $permgen_size   = $jira::params::permgen_size
 ) inherits jira::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,8 @@
 class jira (
   $minimum_memory = $jira::params::minimum_memory,
   $maximum_memory = $jira::params::maximum_memory,
-  $permgen_size   = $jira::params::permgen_size
+  $permgen_size   = $jira::params::permgen_size,
+  $jvm_options    = undef
 ) inherits jira::params {
 
   # validate parameters here

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,10 @@ class jira::params {
   $version = '6.0'
   $home    = '/home/jira'
 
+  $permgen_size    = '384m'
+  $initial_memory  = '384m'
+  $maximum_memory  = '1024m'
+
   case $::osfamily {
     'Debian': {
       $package_name = 'jira'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class jira::params {
   $home    = '/home/jira'
 
   $permgen_size    = '384m'
-  $initial_memory  = '384m'
+  $minimum_memory  = '384m'
   $maximum_memory  = '1024m'
 
   case $::osfamily {

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,4 +6,5 @@ describe 'jira::config' do
   }}
   it { should contain_user('jira') }
   it { should contain_file('/home/jira') }
+  it { should contain_file('setenv.sh') }
 end

--- a/templates/jira-init.erb
+++ b/templates/jira-init.erb
@@ -19,7 +19,7 @@ STOP_SCRIPT="${JIRA_PATH}/bin/stop-jira.sh"
 PIDFILE="${JIRA_PATH}/work/catalina.pid"
 CWD=`pwd`
 
-export JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::initial_memory') %>"
+export JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::minimum_memory') %>"
 export JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('jira::maximum_memory') %>"
 export JIRA_MAX_PERM_SIZE="<%= scope.lookupvar('jira::permgen_size') %>"
 

--- a/templates/jira-init.erb
+++ b/templates/jira-init.erb
@@ -23,6 +23,7 @@ export JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::minimum_memory') %>"
 export JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('jira::maximum_memory') %>"
 export JIRA_MAX_PERM_SIZE="<%= scope.lookupvar('jira::permgen_size') %>"
 
+export JVM_OPTS="<%= scope.lookupvar('jira::jvm_options') %>"
 export JIRA_HOME="<%= scope.lookupvar('jira::params::home') %>"
 
 start () {

--- a/templates/jira-init.erb
+++ b/templates/jira-init.erb
@@ -19,11 +19,10 @@ STOP_SCRIPT="${JIRA_PATH}/bin/stop-jira.sh"
 PIDFILE="${JIRA_PATH}/work/catalina.pid"
 CWD=`pwd`
 
-initial_memory="-Xms<%= scope.lookupvar('jira::params::initial_memory') %>"
-max_memory="-Xmx<%= scope.lookupvar('jira::params::maximum_memory') %>"
-permgen_size="-XX:MaxPermSize=<%= scope.lookupvar('jira::params::permgen_size') %>"
+export JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::initial_memory') %>"
+export JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('jira::maximum_memory') %>"
+export JIRA_MAX_PERM_SIZE="<%= scope.lookupvar('jira::permgen_size') %>"
 
-export CATALINA_OPTS="-Djava.net.preferIPv4Stack=true $permgen_size $initial_memory $permgen_size"
 export JIRA_HOME="<%= scope.lookupvar('jira::params::home') %>"
 
 start () {

--- a/templates/jira-init.erb
+++ b/templates/jira-init.erb
@@ -19,6 +19,11 @@ STOP_SCRIPT="${JIRA_PATH}/bin/stop-jira.sh"
 PIDFILE="${JIRA_PATH}/work/catalina.pid"
 CWD=`pwd`
 
+initial_memory="-Xms<%= scope.lookupvar('jira::params::initial_memory') %>"
+max_memory="-Xmx<%= scope.lookupvar('jira::params::maximum_memory') %>"
+permgen_size="-XX:MaxPermSize=<%= scope.lookupvar('jira::params::permgen_size') %>"
+
+export CATALINA_OPTS="-Djava.net.preferIPv4Stack=true $permgen_size $initial_memory $permgen_size"
 export JIRA_HOME="<%= scope.lookupvar('jira::params::home') %>"
 
 start () {


### PR DESCRIPTION
This allows to set JVM settings such as heap and permgen when calling class jira. It is also possible to add JVM options with the `jvm_options` setting.
